### PR TITLE
rename VOID to XFVOID to avoid collisions with TBB

### DIFF
--- a/include/xflens/cxxlapack/interface/isnan.h
+++ b/include/xflens/cxxlapack/interface/isnan.h
@@ -36,7 +36,7 @@
 #include <complex>
 
 namespace cxxlapack {
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
 isnan(float                 sin);
 

--- a/include/xflens/cxxlapack/interface/isnan.tcc
+++ b/include/xflens/cxxlapack/interface/isnan.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
 isnan(float                 sin)
 {

--- a/include/xflens/cxxlapack/interface/labad.h
+++ b/include/xflens/cxxlapack/interface/labad.h
@@ -37,11 +37,11 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     labad(float  &small, float  &large);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     labad(double &small, double &large);
 

--- a/include/xflens/cxxlapack/interface/labad.tcc
+++ b/include/xflens/cxxlapack/interface/labad.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 labad(float &small, float &large)
 {
@@ -49,7 +49,7 @@ labad(float &small, float &large)
                         &large);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 labad(double &small, double &large)
 {

--- a/include/xflens/cxxlapack/interface/lae2.h
+++ b/include/xflens/cxxlapack/interface/lae2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
 void
     lae2(float                 a,
          float                 b,
@@ -45,7 +45,7 @@ void
          float                 &rt1,
          float                 &rt2);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
 void
     lae2(double                a,
          double                b,

--- a/include/xflens/cxxlapack/interface/lae2.tcc
+++ b/include/xflens/cxxlapack/interface/lae2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lae2(float                 a,
      float                 b,
@@ -56,7 +56,7 @@ lae2(float                 a,
                        &rt2);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lae2(double                a,
      double                b,

--- a/include/xflens/cxxlapack/interface/laesy.h
+++ b/include/xflens/cxxlapack/interface/laesy.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laesy(std::complex<float >  a,
           std::complex<float >  b,
@@ -48,7 +48,7 @@ template <typename VOID=void>
           std::complex<float >  &cs1,
           std::complex<float >  &sn1);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laesy(std::complex<double>  a,
           std::complex<double>  b,

--- a/include/xflens/cxxlapack/interface/laesy.tcc
+++ b/include/xflens/cxxlapack/interface/laesy.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laesy(std::complex<float >  a,
       std::complex<float >  b,
@@ -64,7 +64,7 @@ laesy(std::complex<float >  a,
 
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laesy(std::complex<double>  a,
       std::complex<double>  b,

--- a/include/xflens/cxxlapack/interface/laev2.h
+++ b/include/xflens/cxxlapack/interface/laev2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laev2(float                 a,
           float                 b,
@@ -48,7 +48,7 @@ template <typename VOID=void>
           float                 &sn1);
 
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laev2(double                a,
           double                b,
@@ -58,7 +58,7 @@ template <typename VOID=void>
           double                &cs1,
           double                &sn1);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laev2(std::complex<float >  a,
           std::complex<float >  b,
@@ -68,7 +68,7 @@ template <typename VOID=void>
           float                 &cs1,
           std::complex<float >  &sn1);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     laev2(std::complex<double>  a,
           std::complex<double>  b,

--- a/include/xflens/cxxlapack/interface/laev2.tcc
+++ b/include/xflens/cxxlapack/interface/laev2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laev2(float                 a,
       float                 b,
@@ -61,7 +61,7 @@ laev2(float                 a,
 }
 
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laev2(double                a,
       double                b,
@@ -82,7 +82,7 @@ laev2(double                a,
                         &sn1);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laev2(std::complex<float >  a,
       std::complex<float >  b,
@@ -103,7 +103,7 @@ laev2(std::complex<float >  a,
                         reinterpret_cast<float  *>(&sn1));
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 laev2(std::complex<double>  a,
       std::complex<double>  b,

--- a/include/xflens/cxxlapack/interface/lags2.h
+++ b/include/xflens/cxxlapack/interface/lags2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lags2(bool                  upper,
           float                 a1,
@@ -53,7 +53,7 @@ template <typename VOID=void>
           float                 &csq,
           float                 &snq);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lags2(bool                  upper,
           double                a1,
@@ -69,7 +69,7 @@ template <typename VOID=void>
           double                &csq,
           double                &snq);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lags2(bool                  upper,
           float                 a1,
@@ -85,7 +85,7 @@ template <typename VOID=void>
           float                 &csq,
           std::complex<float >  &snq);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lags2(bool                  upper,
           double                a1,

--- a/include/xflens/cxxlapack/interface/lags2.tcc
+++ b/include/xflens/cxxlapack/interface/lags2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lags2(bool                  upper,
       float                 a1,
@@ -75,7 +75,7 @@ lags2(bool                  upper,
 }
 
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lags2(bool                  upper,
       double                a1,
@@ -110,7 +110,7 @@ lags2(bool                  upper,
 
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lags2(bool                  upper,
       float                 a1,
@@ -146,7 +146,7 @@ lags2(bool                  upper,
 
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lags2(bool                  upper,
       double                a1,

--- a/include/xflens/cxxlapack/interface/laisnan.h
+++ b/include/xflens/cxxlapack/interface/laisnan.h
@@ -37,12 +37,12 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
     laisnan(float                  sin1,
             float                  sin2);
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
     laisnan(double                 din1,
             double                 din2);

--- a/include/xflens/cxxlapack/interface/laisnan.tcc
+++ b/include/xflens/cxxlapack/interface/laisnan.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
 laisnan(float                  sin1,
         float                  sin2)
@@ -50,7 +50,7 @@ laisnan(float                  sin1,
                                  &sin2);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
 laisnan(double                 din1,
         double                 din2)

--- a/include/xflens/cxxlapack/interface/lamch.tcc
+++ b/include/xflens/cxxlapack/interface/lamch.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lamch_(char c, double &value)
 {

--- a/include/xflens/cxxlapack/interface/lanv2.h
+++ b/include/xflens/cxxlapack/interface/lanv2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lanv2(float    &a,
           float    &b,
@@ -50,7 +50,7 @@ template <typename VOID=void>
           float    &cs,
           float    &sn);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lanv2(double   &a,
           double   &b,

--- a/include/xflens/cxxlapack/interface/lanv2.tcc
+++ b/include/xflens/cxxlapack/interface/lanv2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lanv2(float    &a,
       float    &b,
@@ -66,7 +66,7 @@ lanv2(float    &a,
                         &sn);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lanv2(double   &a,
       double   &b,

--- a/include/xflens/cxxlapack/interface/lapy2.h
+++ b/include/xflens/cxxlapack/interface/lapy2.h
@@ -37,11 +37,11 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     float
     lapy2(float x, float y);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     double
     lapy2(double x, double y);
 

--- a/include/xflens/cxxlapack/interface/lapy2.tcc
+++ b/include/xflens/cxxlapack/interface/lapy2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 float
 lapy2(float x, float y)
 {
@@ -49,7 +49,7 @@ lapy2(float x, float y)
 }
 
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 double
 lapy2(double x, double y)
 {

--- a/include/xflens/cxxlapack/interface/lapy3.h
+++ b/include/xflens/cxxlapack/interface/lapy3.h
@@ -37,11 +37,11 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     float
     lapy3(float x, float y, float z);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     double
     lapy3(double x, double y, double z);
 

--- a/include/xflens/cxxlapack/interface/lapy3.tcc
+++ b/include/xflens/cxxlapack/interface/lapy3.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 float
 lapy3(float x, float y, float z)
 {
@@ -48,7 +48,7 @@ lapy3(float x, float y, float z)
     return LAPACK_IMPL(slapy3)(&x, &y, &z);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 double
 lapy3(double x, double y, double z)
 {

--- a/include/xflens/cxxlapack/interface/lartg.h
+++ b/include/xflens/cxxlapack/interface/lartg.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartg(const float      &f,
           const float      &g,
@@ -45,7 +45,7 @@ template <typename VOID=void>
           float            &sn,
           float            &r);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartg(const double     &f,
           const double     &g,
@@ -53,7 +53,7 @@ template <typename VOID=void>
           double           &sn,
           double           &r);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartg(const std::complex<float >    &f,
           const std::complex<float >    &g,
@@ -61,7 +61,7 @@ template <typename VOID=void>
           std::complex<float >          &sn,
           std::complex<float >          &r);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartg(const std::complex<double>    &f,
           const std::complex<double>    &g,

--- a/include/xflens/cxxlapack/interface/lartg.tcc
+++ b/include/xflens/cxxlapack/interface/lartg.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartg(const float      &f,
       const float      &g,
@@ -57,7 +57,7 @@ lartg(const float      &f,
 }
 
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartg(const double     &f,
       const double     &g,
@@ -74,7 +74,7 @@ lartg(const double     &f,
                         &r);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartg(const std::complex<float >    &f,
       const std::complex<float >    &g,
@@ -91,7 +91,7 @@ lartg(const std::complex<float >    &f,
                         reinterpret_cast<float  *>(&r));
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartg(const std::complex<double>    &f,
       const std::complex<double>    &g,

--- a/include/xflens/cxxlapack/interface/lartgp.h
+++ b/include/xflens/cxxlapack/interface/lartgp.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartgp(float                 f,
            float                 g,
@@ -45,7 +45,7 @@ template <typename VOID=void>
            float                 &sn,
            float                 &r);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartgp(double                f,
            double                g,

--- a/include/xflens/cxxlapack/interface/lartgp.tcc
+++ b/include/xflens/cxxlapack/interface/lartgp.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartgp(float                 f,
        float                 g,
@@ -56,7 +56,7 @@ lartgp(float                 f,
                          &r);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartgp(double                f,
        double                g,

--- a/include/xflens/cxxlapack/interface/lartgs.h
+++ b/include/xflens/cxxlapack/interface/lartgs.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartgs(float                 x,
            float                 y,
@@ -45,7 +45,7 @@ template <typename VOID=void>
            float                 &cs,
            float                 &sn);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lartgs(double                x,
            double                y,

--- a/include/xflens/cxxlapack/interface/lartgs.tcc
+++ b/include/xflens/cxxlapack/interface/lartgs.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartgs(float                 x,
        float                 y,
@@ -56,7 +56,7 @@ lartgs(float                 x,
                          &sn);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lartgs(double                x,
        double                y,

--- a/include/xflens/cxxlapack/interface/las2.h
+++ b/include/xflens/cxxlapack/interface/las2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     las2 (float                 f,
           float                 g,
@@ -45,7 +45,7 @@ template <typename VOID=void>
           float                 &ssmin,
           float                 &ssmax);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     las2 (double                f,
           double                g,

--- a/include/xflens/cxxlapack/interface/las2.tcc
+++ b/include/xflens/cxxlapack/interface/las2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 las2 (float                 f,
       float                 g,
@@ -56,7 +56,7 @@ las2 (float                 f,
                         &ssmax);
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 las2 (double                f,
       double                g,

--- a/include/xflens/cxxlapack/interface/lasv2.h
+++ b/include/xflens/cxxlapack/interface/lasv2.h
@@ -37,7 +37,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     void
     lasv2(float                 f,
           float                 g,
@@ -49,7 +49,7 @@ template <typename VOID=void>
           float                 &snl,
           float                 &csl);
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
 void
 lasv2(double                f,
       double                g,

--- a/include/xflens/cxxlapack/interface/lasv2.tcc
+++ b/include/xflens/cxxlapack/interface/lasv2.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lasv2(float                 f,
       float                 g,
@@ -65,7 +65,7 @@ lasv2(float                 f,
 
 }
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 void
 lasv2(double                f,
       double                g,

--- a/include/xflens/cxxlapack/interface/lsame.h
+++ b/include/xflens/cxxlapack/interface/lsame.h
@@ -38,7 +38,7 @@
 namespace cxxlapack {
 
 
-template <typename VOID=void>
+template <typename XFLENS_VOID=void>
     bool
     lsame(char                  ca,
           char                  cb);

--- a/include/xflens/cxxlapack/interface/lsame.tcc
+++ b/include/xflens/cxxlapack/interface/lsame.tcc
@@ -39,7 +39,7 @@
 
 namespace cxxlapack {
 
-template <typename VOID>
+template <typename XFLENS_VOID>
 bool
 lsame(char                  ca,
       char                  cb)


### PR DESCRIPTION
This is to potentially fix some incompatibility with TBB (https://github.com/xtensor-stack/xtensor/issues/1816) 

Even though I could not reproduce it locally.

@cemoktra could you try this PR?