### PR TITLE
Minor cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,10 @@ if (CXXBLAS_DEBUG)
 endif()
 
 OPTION(BUILD_TESTS "xtensor-blas test suite" OFF)
-OPTION(DOWNLOAD_GTEST "build gtest from downloaded sources" OFF)
+OPTION(BUILD_BENCHMARK "xtensor-blas test suite" OFF)
 
-OPTION(BUILD_BENCHMARKS "xtensor-blas test suite" OFF)
-OPTION(DOWNLOAD_GBENCHMARK "build gtest from downloaded sources" OFF)
+OPTION(DOWNLOAD_GTEST "download gtest and build from source" OFF)
+OPTION(DOWNLOAD_GBENCHMARK "download google benchmark and build from source" OFF)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     set(BUILD_TESTS ON)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -12,7 +12,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-benchmark)
 
     find_package(xtensor REQUIRED CONFIG)
-    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIR})
+    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIRS})
 endif ()
 
 message(STATUS "Forcing tests build type to Release")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,7 +110,6 @@ include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
 include_directories(${XTENSOR_INCLUDE_DIR})
 include_directories(${XBLAS_INCLUDE_DIR})
 
-find_package(xtensor REQUIRED)
 if(USE_OPENBLAS)
     find_package(OpenBLAS REQUIRED)
     set(BLAS_LIBRARIES ${CMAKE_INSTALL_PREFIX}${OpenBLAS_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,13 +13,17 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-blas-test)
 
     find_package(xtensor REQUIRED CONFIG)
-    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIR})
+    set(XTENSOR_INCLUDE_DIR ${xtensor_INCLUDE_DIRS})
     find_package(xtensor-blas REQUIRED CONFIG)
     set(XTENSOR_BLAS_INCLUDE_DIR ${xblas_INCLUDE_DIRS})
 endif ()
 
-message(STATUS "Forcing tests build type to Release")
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting tests build type to Release")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+else()
+    message(STATUS "Tests build type is ${CMAKE_BUILD_TYPE}")
+endif()
 
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
This PR fixes a few minor issues for `xtensor-blas`:
  * The variable `xtensor_INCLUDE_DIR` should probably be named `xtensor_INCLUDE_DIRS`?
  * `CMAKE_BUILD_TYPE` should only be overwritten if not explicitly set by the user
  * A duplicate call to `find_package(xtensor REQUIRED)` in https://github.com/xtensor-stack/xtensor-blas/compare/master...BioDataAnalysis:emmenlau_minor_cmake_fixes?expand=1#diff-15547c54d3d4898a882b4ab7b3cee381L113 leads to compile errors like:
```
CMake Error at /data/Debug/lib/cmake/xtensor/xtensorConfig.cmake:53 (target_link_libraries):
Cannot specify link libraries for target "xtensor" which is not built by this project.
Call Stack (most recent call first):
test/CMakeLists.txt:117 (find_package)
```