### PR TITLE
Improved c++14/17 integration, follows more closely modern cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ target_include_directories(xtensor-blas
     $<INSTALL_INTERFACE:include>)
 
 OPTION(CXXBLAS_DEBUG "print cxxblas debug information" OFF)
+OPTION(CPP17 "enables C++17" OFF)
 OPTION(XTENSOR_USE_FLENS_BLAS "use FLENS generic implementation instead of cblas" OFF)
 # Decide whether to use OpenBLAS or not.
 # The user might have the folder containing OpenBLASConfig.cmake file

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -24,13 +24,6 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder")
-    CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
-
-    if (HAS_CPP14_FLAG)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    else()
-        message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
-    endif()
 
     # Enable link time optimization and set the default symbol
     # visibility to hidden (very important to obtain small binaries)
@@ -124,6 +117,12 @@ set(XTENSOR_BENCHMARK
 set(XTENSOR_BENCHMARK_TARGET benchmark_xtensor)
 add_executable(${XTENSOR_BENCHMARK_TARGET} EXCLUDE_FROM_ALL ${XTENSOR_BENCHMARK} ${XTENSOR_HEADERS})
 target_link_libraries(${XTENSOR_BENCHMARK_TARGET} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GBENCHMARK_LIBRARIES})
+if(CPP17)
+    target_compile_features(${XTENSOR_BENCHMARK_TARGET} PUBLIC cxx_std_17)
+else()
+    target_compile_features(${XTENSOR_BENCHMARK_TARGET} PUBLIC cxx_std_14)
+endif()
+
 
 add_custom_target(xbenchmark
     COMMAND benchmark_xtensor

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,34 +25,6 @@ else()
     message(STATUS "Tests build type is ${CMAKE_BUILD_TYPE}")
 endif()
 
-include(CheckCXXCompilerFlag)
-
-string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
-
-include(set_compiler_flag.cmake)
-
-if(CPP17)
-  # User requested C++17, but compiler might not oblige.
-  set_compiler_flag(
-    _cxx_std_flag CXX
-    "-std=c++17"  # this should work with GNU, Intel, PGI
-    "/std:c++17"  # this should work with MSVC
-  )
-  if(_cxx_std_flag)
-    message(STATUS "Building with C++17")
-  endif()
-else()
-  set_compiler_flag(
-    _cxx_std_flag CXX REQUIRED
-    "-std=c++14"  # this should work with GNU, Intel, PGI
-    "/std:c++14"  # this should work with MSVC
-  )
-  message(STATUS "Building with C++14")
-endif()
-
-if(NOT _cxx_std_flag)
-  message(FATAL_ERROR "xtensor-blas needs a C++14-compliant compiler.")
-endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
@@ -146,5 +118,10 @@ if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
 endif()
 
 target_link_libraries(test_xtensor_blas ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(CPP17)
+    target_compile_features(test_xtensor_blas PUBLIC cxx_std_17)
+else()
+    target_compile_features(test_xtensor_blas PUBLIC cxx_std_14)
+endif()
 
 add_custom_target(xtest COMMAND test_xtensor_blas DEPENDS test_xtensor_blas)


### PR DESCRIPTION
Currently xtensor-blas supports cmake prior to 3.8 by *not* using `target_compile_features` to set the c++14/17 standard. This can be a problem when mixed with projects that do use `target_compile_features` to set the standard, because cmake will not match the two choices. Therefore with the current implementation, both flags may be effective at the same time, which can result in compiler options like
```
cc ... -std=c++17 ... -std=gnu++11 ...
```
where the later option wins.

If xtensor should continue to support cmake prior to 3.8, then I propose to use `target_compile_features` when a sufficiently recent cmake is found. Otherwise I'd recommend to set the minimum cmake to 3.8?