### PR TITLE
Remove self-inclusion in both interface files.

### DIFF
--- a/include/xflens/cxxlapack/interface/interface.h
+++ b/include/xflens/cxxlapack/interface/interface.h
@@ -182,7 +182,6 @@
 #include "xflens/cxxlapack/interface/ilaver.h"
 #include "xflens/cxxlapack/interface/ilazlc.h"
 #include "xflens/cxxlapack/interface/ilazlr.h"
-#include "xflens/cxxlapack/interface/interface.h"
 #include "xflens/cxxlapack/interface/isnan.h"
 #include "xflens/cxxlapack/interface/izmax1.h"
 #include "xflens/cxxlapack/interface/labad.h"

--- a/include/xflens/cxxlapack/interface/interface.tcc
+++ b/include/xflens/cxxlapack/interface/interface.tcc
@@ -180,7 +180,6 @@
 #include "xflens/cxxlapack/interface/ilaver.tcc"
 #include "xflens/cxxlapack/interface/ilazlc.tcc"
 #include "xflens/cxxlapack/interface/ilazlr.tcc"
-#include "xflens/cxxlapack/interface/interface.tcc"
 #include "xflens/cxxlapack/interface/isnan.tcc"
 #include "xflens/cxxlapack/interface/izmax1.tcc"
 #include "xflens/cxxlapack/interface/labad.tcc"


### PR DESCRIPTION
The fix of the issue #177: both self-inclusion in xflens interface files have been removed.

Of course this modification makes sense only if both files modified aren't generated automatically from a script (I didn't delve into your codebase to check that - I just share here the fix I did locally to be able to run include-what-you-use on my code without unexpected crash).