### PR TITLE
Adds missing CMakeFindDependencyMacro include.

### DIFF
--- a/xtensor-blasConfig.cmake.in
+++ b/xtensor-blasConfig.cmake.in
@@ -17,6 +17,7 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET @PROJECT_NAME@)
+  include(CMakeFindDependencyMacro)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
   get_target_property(@PROJECT_NAME@_INCLUDE_DIRS xtensor-blas INTERFACE_INCLUDE_DIRECTORIES)
   find_dependency(BLAS REQUIRED)


### PR DESCRIPTION
CMakeFindDependencyMacro  defines `find_dependency()` and needs to be included before calling `find_dependency()`.