### PR TITLE
labad: Renamed 'small' to 'smallv' to avoid problems with define in rpcndr.h on MSVC

### DIFF
--- a/include/xflens/cxxlapack/interface/labad.h
+++ b/include/xflens/cxxlapack/interface/labad.h
@@ -39,11 +39,11 @@ namespace cxxlapack {
 
 template <typename XFLENS_VOID=void>
     void
-    labad(float  &small, float  &large);
+    labad(float  &smallv, float  &largev);
 
 template <typename XFLENS_VOID=void>
     void
-    labad(double &small, double &large);
+    labad(double &smallv, double &largev);
 
 } // namespace cxxlapack
 

--- a/include/xflens/cxxlapack/interface/labad.tcc
+++ b/include/xflens/cxxlapack/interface/labad.tcc
@@ -41,22 +41,22 @@ namespace cxxlapack {
 
 template <typename XFLENS_VOID>
 void
-labad(float &small, float &large)
+labad(float &smallv, float &largev)
 {
     CXXLAPACK_DEBUG_OUT("slabad");
 
-    LAPACK_IMPL(slabad)(&small,
-                        &large);
+    LAPACK_IMPL(slabad)(&smallv,
+                        &largev);
 }
 
 template <typename XFLENS_VOID>
 void
-labad(double &small, double &large)
+labad(double &smallv, double &largev)
 {
     CXXLAPACK_DEBUG_OUT("dlabad");
 
-    LAPACK_IMPL(dlabad)(&small,
-                        &large);
+    LAPACK_IMPL(dlabad)(&smallv,
+                        &largev);
 }
 
 


### PR DESCRIPTION
This PR solves a similar problem as https://github.com/xtensor-stack/xtensor-blas/pull/149 before, again on MSVC. This time the error comes from the header `C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\shared\rpcndr.h` on MSVC that has a define
```
#define small char
```
which breaks arguments in labad.h and labad.tcc.