### PR TITLE
relax tolerance in the xlapack.solveCholesky test

### DIFF
--- a/test/test_lapack.cpp
+++ b/test/test_lapack.cpp
@@ -163,7 +163,7 @@ namespace xt
                                             -1.3449222878385465 , -1.81183493755905478};
 
         for (int i = 0; i < x_expected.shape()[0]; ++i) {
-          EXPECT_NEAR(x_expected[i], x[i], 2e-16);
+          EXPECT_NEAR(x_expected[i], x[i], 5e-16);
         }
     }
 


### PR DESCRIPTION
The xlapack.solveCholesky test in test_lapack.cpp fails on 32-bit architectures (i386/i686):
[ RUN      ] xlapack.solveCholesky
/tmp/autopkgtest-lxc.gg3nslld/downtmp/autopkgtest_tmp/test_lapack.cpp:166: Failure
Expected equality of these values:
  x_expected[i]
    Which is: 0.13757507429403265
  x[i]
    Which is: 0.13757507429403248
[  FAILED  ] xlapack.solveCholesky (0 ms)

This patch relaxes test tolerance by using EXPECT_NEAR with abstol=2e-16 instead of EXPECT_DOUBLE_EQ.

Fixes Issue #211.