### PR TITLE
fix trace for complex vals

### DIFF
--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -1474,7 +1474,7 @@ namespace linalg
     template <class T>
     auto trace(const xexpression<T>& M, int offset = 0, int axis1 = 0, int axis2 = 1)
     {
-        const auto& dM = M.derived_cast();
+        auto&& dM = xt::view_eval<T::static_layout>(M.derived_cast());
         auto d = xt::diagonal(dM, offset, std::size_t(axis1), std::size_t(axis2));
 
         std::size_t dim = d.dimension();

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -1474,17 +1474,18 @@ namespace linalg
     template <class T>
     auto trace(const xexpression<T>& M, int offset = 0, int axis1 = 0, int axis2 = 1)
     {
+        using value_type = std::common_type_t<typename T::value_type>;
         auto&& dM = xt::view_eval<T::static_layout>(M.derived_cast());
         auto d = xt::diagonal(dM, offset, std::size_t(axis1), std::size_t(axis2));
 
         std::size_t dim = d.dimension();
         if (dim == 1)
         {
-            return xt::xarray<double>(xt::sum(d)());
+            return xt::xarray<value_type, T::static_layout>(xt::sum(d)());
         }
         else
         {
-            return xt::xarray<double>(xt::sum(d, {dim - 1}));
+            return xt::xarray<value_type, T::static_layout>(xt::sum(d, {dim - 1}));
         }
     }
 

--- a/test/test_linalg.cpp
+++ b/test/test_linalg.cpp
@@ -497,6 +497,11 @@ namespace xt
         EXPECT_EQ(12, ar1());
         EXPECT_EQ(6,  ar2());
         EXPECT_EQ(10, ar3());
+
+        xarray<std::complex<double>> ar2 = random::rand<double>({ 2, 3, 1, 3 });
+        xarray<std::complex<double>> ar3 = linalg::trace(ar2, 0, 1, 3);
+
+        EXPECT_EQ(ar3.shape(), { 2, 1 });
     }
 
     TEST(xlinalg, dots)

--- a/test/test_linalg.cpp
+++ b/test/test_linalg.cpp
@@ -498,10 +498,10 @@ namespace xt
         EXPECT_EQ(6,  ar2());
         EXPECT_EQ(10, ar3());
 
-        xarray<std::complex<double>> ar2 = random::rand<double>({ 2, 3, 1, 3 });
-        xarray<std::complex<double>> ar3 = linalg::trace(ar2, 0, 1, 3);
+        xarray<std::complex<double>> ar4 = random::rand<double>({ 2, 3, 1, 3 });
+        xarray<std::complex<double>> ar5 = linalg::trace(ar4, 0, 1, 3);
 
-        EXPECT_EQ(ar3.shape(), { 2, 1 });
+        EXPECT_EQ(ar5.shape(), { 2, 1 });
     }
 
     TEST(xlinalg, dots)


### PR DESCRIPTION
Regarding #141:

Changing
```
const auto& dM = M.derived_cast();
```
to
```
auto&& dM = xt::view_eval<T::static_layout>(M.derived_cast());
```
should do it.