### PR TITLE
Fix compile warnings

### DIFF
--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -94,9 +94,9 @@ namespace xt
                 {
                     for (std::size_t i = 0; i < v.size(); ++i)
                     {
-                        result += std::abs(std::pow(v(i), ord));
+                        result += static_cast<underlying_value_type>(std::abs(std::pow(v(i), ord)));
                     }
-                    result = std::pow(result, 1. / static_cast<double>(ord));
+                    result = static_cast<underlying_value_type>(std::pow(result, 1. / static_cast<double>(ord)));
                 }
                 return result;
             }

--- a/test/test_lapack.cpp
+++ b/test/test_lapack.cpp
@@ -178,7 +178,7 @@ namespace xt
             -1.3449222878385465,
             -1.81183493755905478};
 
-        for (int i = 0; i < x_expected.shape()[0]; ++i)
+        for (std::size_t i = 0; i < x_expected.shape()[0]; ++i)
         {
             EXPECT_NEAR(x_expected[i], x[i], 5e-16);
         }
@@ -203,7 +203,7 @@ namespace xt
             -0.05799057434472885,
             0.08606304705465571};
 
-        for (int i = 0; i < x_expected.shape()[0]; ++i)
+        for (std::size_t i = 0; i < x_expected.shape()[0]; ++i)
         {
             EXPECT_DOUBLE_EQ(x_expected[i], x[i]);
         }


### PR DESCRIPTION
This PR fixes a couple of compiler warnings related to integers and floats of different size highlighted by clang-13.