### PR TITLE
eigh size fix

### DIFF
--- a/include/xtensor-blas/xlapack.hpp
+++ b/include/xtensor-blas/xlapack.hpp
@@ -609,6 +609,9 @@ namespace xt
                 XTENSOR_THROW(std::runtime_error, "Could not find workspace size for syevd.");
             }
 
+            int min_size = 1 + 6*N + (2*N)*(2*N);
+            if(work[0]<min_size) work[0] = min_size;
+
             work.resize(std::size_t(work[0]));
             iwork.resize(std::size_t(iwork[0]));
 


### PR DESCRIPTION
Fixed eigh() when the Matrix is too big.
The first time syevd is called is to get the work size, but sometimes the size returned is less than the minimum size allowed. Adding a simple condition fixed it for me.