### PR TITLE
BLD: Add a pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,12 @@ install(DIRECTORY ${INCLUDE_DIR}/xflens
         PATTERN filter.pm EXCLUDE
         PATTERN CMakeLists.txt EXCLUDE)
 
+configure_file(${PROJECT_NAME}.pc.in
+               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+                @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/pkgconfig/")
+
 set(XTENSOR_BLAS_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE
     STRING "install path for xtensor-blasConfig.cmake")
 

--- a/xtensor-blas.pc.in
+++ b/xtensor-blas.pc.in
@@ -1,0 +1,7 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+
+Name: xtensor-blas
+Description: An extension to the xtensor library, offering bindings to BLAS and LAPACK libraries.
+Version: @xtensor-blas_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
Super useful for `meson`, and seems to have been missed for `xtensor-blas`, it is generated for every other sub-project of the xtensor-stack.