### PR TITLE
Updated include paths for xtensor 0.26.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message(STATUS "xtensor-blas v${${PROJECT_NAME}_VERSION}")
 # Dependencies
 # ============
 
-set(xtensor_REQUIRED_VERSION 0.25.0)
+set(xtensor_REQUIRED_VERSION 0.26.0)
 if(TARGET xtensor)
     set(xtensor_VERSION ${XTENSOR_VERSION_MAJOR}.${XTENSOR_VERSION_MINOR}.${XTENSOR_VERSION_PATCH})
     # Note: This is not SEMVER compatible comparison

--- a/benchmark/benchmark_blas.hpp
+++ b/benchmark/benchmark_blas.hpp
@@ -11,9 +11,9 @@
 
 #include <benchmark/benchmark.h>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "xtensor-blas/xlinalg.hpp"
 

--- a/include/xtensor-blas/xblas.hpp
+++ b/include/xtensor-blas/xblas.hpp
@@ -12,11 +12,11 @@
 
 #include <algorithm>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xutils.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/misc/xcomplex.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/utils/xutils.hpp"
 
 #include "xflens/cxxblas/cxxblas.cxx"
 #include "xtensor-blas/xblas_config.hpp"

--- a/include/xtensor-blas/xblas_utils.hpp
+++ b/include/xtensor-blas/xblas_utils.hpp
@@ -14,7 +14,7 @@
 #include <tuple>
 #include <type_traits>
 
-#include "xtensor/xutils.hpp"
+#include "xtensor/utils/xutils.hpp"
 
 #include "xflens/cxxblas/typedefs.h"
 #include "xtensor-blas/xblas_config.hpp"

--- a/include/xtensor-blas/xlapack.hpp
+++ b/include/xtensor-blas/xlapack.hpp
@@ -12,12 +12,12 @@
 
 #include <algorithm>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xstorage.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xutils.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/misc/xcomplex.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/containers/xstorage.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/utils/xutils.hpp"
 
 #include "xflens/cxxlapack/cxxlapack.cxx"
 #include "xtensor-blas/xblas_config.hpp"

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -15,15 +15,15 @@
 #include <limits>
 #include <sstream>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xeval.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xmanipulation.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xutils.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/misc/xcomplex.hpp"
+#include "xtensor/core/xeval.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/misc/xmanipulation.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/utils/xutils.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "xtensor-blas/xblas.hpp"
 #include "xtensor-blas/xblas_utils.hpp"

--- a/test/test_blas.cpp
+++ b/test/test_blas.cpp
@@ -7,10 +7,10 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xrandom.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/generators/xrandom.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xblas.hpp"

--- a/test/test_dot.cpp
+++ b/test/test_dot.cpp
@@ -7,10 +7,10 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xlinalg.hpp"

--- a/test/test_dot_extended.cpp
+++ b/test/test_dot_extended.cpp
@@ -12,8 +12,8 @@
 
 #include <algorithm>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xlinalg.hpp"

--- a/test/test_float_norm.cpp
+++ b/test/test_float_norm.cpp
@@ -9,10 +9,10 @@
 
 // this test is for https://github.com/xtensor-stack/xtensor-blas/issues/206
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xrandom.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/generators/xrandom.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xblas.hpp"

--- a/test/test_generator/cppy_source/test_dot_extended.cppy
+++ b/test/test_generator/cppy_source/test_dot_extended.cppy
@@ -10,8 +10,8 @@
 #include <algorithm>
 
 #include "gtest/gtest.h"
-#include "xtensor/xarray.hpp"
-#include "xtensor/xtensor.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xtensor.hpp"
 
 #include "xtensor-blas/xlinalg.hpp"
 

--- a/test/test_generator/cppy_source/test_lstsq.cppy
+++ b/test/test_generator/cppy_source/test_lstsq.cppy
@@ -10,12 +10,12 @@
 #include <algorithm>
 
 #include "gtest/gtest.h"
-#include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xfixed.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "xtensor-blas/xlinalg.hpp"
 

--- a/test/test_generator/cppy_source/test_qr.cppy
+++ b/test/test_generator/cppy_source/test_qr.cppy
@@ -10,12 +10,12 @@
 #include <algorithm>
 
 #include "gtest/gtest.h"
-#include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xfixed.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "xtensor-blas/xlinalg.hpp"
 

--- a/test/test_lapack.cpp
+++ b/test/test_lapack.cpp
@@ -7,11 +7,11 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/misc/xcomplex.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xblas.hpp"

--- a/test/test_linalg.cpp
+++ b/test/test_linalg.cpp
@@ -7,12 +7,12 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xio.hpp"
-#include "xtensor/xrandom.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/misc/xcomplex.hpp"
+#include "xtensor/io/xio.hpp"
+#include "xtensor/generators/xrandom.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xblas.hpp"

--- a/test/test_lstsq.cpp
+++ b/test/test_lstsq.cpp
@@ -12,12 +12,12 @@
 
 #include <algorithm>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xfixed.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xlinalg.hpp"

--- a/test/test_qr.cpp
+++ b/test/test_qr.cpp
@@ -12,12 +12,12 @@
 
 #include <algorithm>
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/containers/xfixed.hpp"
+#include "xtensor/core/xnoalias.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/containers/xtensor.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xlinalg.hpp"

--- a/test/test_tensordot.cpp
+++ b/test/test_tensordot.cpp
@@ -7,10 +7,10 @@
  * The full license is in the file LICENSE, distributed with this software. *
  ****************************************************************************/
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xview.hpp"
+#include "xtensor/containers/xarray.hpp"
+#include "xtensor/generators/xbuilder.hpp"
+#include "xtensor/views/xstrided_view.hpp"
+#include "xtensor/views/xview.hpp"
 
 #include "gtest/gtest.h"
 #include "xtensor-blas/xlinalg.hpp"


### PR DESCRIPTION
This PR updates the includes, to support building against xtensor 0.26.0.