### PR TITLE
Fix using xtensor-blas with xeus-cpp-lite

### DIFF
--- a/include/xtensor-blas/xblas_config_cling.hpp.in
+++ b/include/xtensor-blas/xblas_config_cling.hpp.in
@@ -26,7 +26,7 @@
 
 #include <clang/Interpreter/CppInterOp.h>
 static bool _openblas_loaded = []() {
-    Cpp::LoadLibrary(@OPENBLAS_CPPINTEROP_LIBRARY_PATH@, false);
+    Cpp::LoadLibrary("/lib/@CMAKE_SHARED_LIBRARY_PREFIX@openblas@CMAKE_SHARED_LIBRARY_SUFFIX@", false);
     return true;
 }();
 


### PR DESCRIPTION
Sadly #252 didn't pick up one of my local changes, not sure how, I remember adding everything.

But yeah that placeholder was supposed to be replaced by its path :(

Just realized this when I tried it out 

<img width="652" height="401" alt="image" src="https://github.com/user-attachments/assets/0b6bee57-476c-429e-bc6d-8f750de9b0dc" />
